### PR TITLE
Fix issue with wrong archel count

### DIFF
--- a/nrresqml/summarization/thumbnail.py
+++ b/nrresqml/summarization/thumbnail.py
@@ -13,6 +13,7 @@ ColorLegend = Dict[str, str]  # Archel id (as str) --> css color
 def make_thumbnail_image(
     resqml_data: ResQmlData, outdir: pathlib.Path, background_archels: list[int] = [0, 6]
 ) -> Tuple[ColorLegend, BBox]:
+    outdir.mkdir(exist_ok=True, parents=True)
     archel = resqml_data.archel
     x0 = resqml_data.x0
     y0 = resqml_data.y0


### PR DESCRIPTION
Error caused (probably) by "old" models storing "archel" as float32, whereas new models use int32, leading to error in a == comparison

BEGIN_COMMIT_OVERRIDE
fix: Fix issue with wrong archel count
END_COMMIT_OVERRIDE